### PR TITLE
Bump DMN parser to resolve special characters parsing issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "author": "Andre Hegerath <andre.hegerath@hbt.de>",
   "dependencies": {
     "big.js": "^3.1.3",
-    "dmn-moddle": "^6.0.0",
+    "dmn-moddle": "^4.0.0",
     "lodash": "^4.17.4",
     "loglevel": "^1.6.1",
     "moment": "^2.21.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "author": "Andre Hegerath <andre.hegerath@hbt.de>",
   "dependencies": {
     "big.js": "^3.1.3",
-    "dmn-moddle": "^1.0.0",
+    "dmn-moddle": "^6.0.0",
     "lodash": "^4.17.4",
     "loglevel": "^1.6.1",
     "moment": "^2.21.0",


### PR DESCRIPTION
It looks like previously FEEL expressions in entries were presented in CDATA value. Now the most recent Camunda DMN Modeler (1.16.2) saves DMN files with normally escaped special characters like this:
`<inputEntry id="UnaryTests_05akr2s">
    <text>&lt; 20</text>
</inputEntry>`

But DMN parser in dmn-moddle 1.0.0/moddle-xml 2.1.1 doesn't unescape them failing with error:
> Error: Failed to parse input entry: &lt; 20 SyntaxError: Expected "(", "-", ".", "<", "<=", ">", ">=", "FALSE", "False", "TRUE", "True", "[", "]", "date and time", "date", "duration", "false", "null", "time", "true", [0-9], [?], [A-Z], [_], [a-z], [̀-ͯ҃-֑҇-ֽֿׁ-ׂׄ-ׇׅؐ-ًؚ-ٰٟۖ-ۜ۟-ۤۧ-۪ۨ-ܑۭܰ-݊ަ-ް߫-߳ࠖ-࠙ࠛ-ࠣࠥ-ࠧࠩ-࡙࠭-࡛ࣣ-ंऺ़ु-ै्॑-ॗॢ-ॣঁ়ু-ৄ্ৢ-ৣਁ-ਂ਼ੁ-ੂੇ-ੈੋ-੍ੑੰ-ੱੵઁ-ં઼ુ-ૅે-ૈ્ૢ-ૣଁ଼ିୁ-ୄ୍ୖୢ-ୣஂீ்ఀా-ీె-ైొ-్ౕ-ౖౢ-ౣಁ಼ಿೆೌ-್ೢ-ೣഁു-ൄ്ൢ-ൣ්ි-ුූัิ-ฺ็-๎ັິ-ູົ-ຼ່-ໍ༘-ཱ༹༙༵༷-ཾྀ-྄྆-྇ྍ-ྗྙ-ྼ࿆ိ-ူဲ-့္-်ွ-ှၘ-ၙၞ-ၠၱ-ၴႂႅ-ႆႍႝ፝-፟ᜒ-᜔ᜲ-᜴ᝒ-ᝓᝲ-ᝳ឴-឵ិ-ួំ៉-៓៝᠋-᠍ᢩᤠ-ᤢᤧ-ᤨᤲ᤹-᤻ᨗ-ᨘᨛᩖᩘ-ᩞ᩠ᩢᩥ-ᩬᩳ-᩿᩼᪰-᪽ᬀ-ᬃ᬴ᬶ-ᬺᬼᭂ᭫-᭳ᮀ-ᮁᮢ-ᮥᮨ-ᮩ᮫-ᮭ᯦ᯨ-ᯩᯭᯯ-ᯱᰬ-ᰳᰶ-᰷᳐-᳔᳒-᳢᳠-᳨᳭᳴᳸-᳹᷀-᷵᷼-᷿⃐-⃥⃜⃡-⃰⳯-⵿⳱ⷠ-〪ⷿ-゙〭-゚꙯ꙴ-꙽ꚞ-ꚟ꛰-꛱ꠂ꠆ꠋꠥ-ꠦ꣄꣠-꣱ꤦ-꤭ꥇ-ꥑꦀ-ꦂ꦳ꦶ-ꦹꦼꧥꨩ-ꨮꨱ-ꨲꨵ-ꨶꩃꩌꩼꪰꪲ-ꪴꪷ-ꪸꪾ-꪿꫁ꫬ-ꫭ꫶ꯥꯨ꯭ﬞ︀-️︠-︯], string, or whitespace but "&" found.
    at rule.inputEntry.forEach (/Users/dmitryg/Development/agr/dmn/engine/_research/node_modules/@hbtgmbh/dmn-eval-js/utils/helper/decision-table-xml.js:31:13)

Details can be found in parser [issue](https://github.com/bpmn-io/moddle-xml/issues/30).
It got fixed in moddle-xml@5.0.1 so I've chosen dmn-moddle@4.0.0/moddle-xml@6.0.0 to be used in dmn-eval-js as it's the latest version that works smoothly (as ES Modules are still experimental in Node.js)