### PR TITLE
Cannot parse valid dmn file

### DIFF
--- a/utils/helper/decision-table-xml.js
+++ b/utils/helper/decision-table-xml.js
@@ -100,18 +100,20 @@ function parseDecisions(drgElements) {
   const parsedDecisions = [];
   // iterate over all decisions in the DMN
   drgElements.forEach((drgElement) => {
-    // parse the decision table...
-    const decision = { decisionTable: parseDecisionTable(drgElement.id, drgElement.decisionTable), requiredDecisions: [] };
-    // ...and collect the decisions on which the current decision depends
-    if (drgElement.informationRequirement !== undefined) {
-      drgElement.informationRequirement.forEach((req) => {
-        if (req.requiredDecision !== undefined) {
-          const requiredDecisionId = req.requiredDecision.href.replace('#', '');
-          decision.requiredDecisions.push(requiredDecisionId);
-        }
-      });
+    if (drgElement.decisionTable) {
+      // parse the decision table...
+      const decision = { decisionTable: parseDecisionTable(drgElement.id, drgElement.decisionTable), requiredDecisions: [] };
+      // ...and collect the decisions on which the current decision depends
+      if (drgElement.informationRequirement !== undefined) {
+        drgElement.informationRequirement.forEach((req) => {
+          if (req.requiredDecision !== undefined) {
+            const requiredDecisionId = req.requiredDecision.href.replace('#', '');
+            decision.requiredDecisions.push(requiredDecisionId);
+          }
+        });
+      }
+      parsedDecisions[drgElement.id] = decision;
     }
-    parsedDecisions[drgElement.id] = decision;
   });
   return parsedDecisions;
 }


### PR DESCRIPTION
I am not able to use `decisionTable.parseDmnXml(xml)` to parse the dmn file used as example for the [Camunda DMN Simulator](https://camunda.com/dmn/simulator/). This File was validated against the official [DMN 1.1 XSD](https://www.omg.org/spec/DMN/20151101/dmn.xsd). 

The Error Message says:

> TypeError: Cannot read property 'hitPolicy' of undefined
    at parseDecisionTable (...\node_modules\@hbtgmbh\dmn-eval-js\utils\helper\decision-table-xml.js:53:22)
    at drgElements.forEach (...\node_modules\@hbtgmbh\dmn-eval-js\utils\helper\decision-table-xml.js:105:41)
    at Array.forEach (<anonymous>)
    at parseDecisions (...\node_modules\@hbtgmbh\dmn-eval-js\utils\helper\decision-table-xml.js:102:15)
    at readDmnXml ...\node_modules\@hbtgmbh\dmn-eval-js\utils\helper\decision-table-xml.js:128:29)
    at Timeout._onTimeout (...\node_modules\moddle-xml\lib\reader.js:830:5)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10)

The issue is related to the function `parseDecisions` because it tries to parse parts parsed xml it shouldnt parse.